### PR TITLE
chore: re-add maps_android_places_upgrade snippet

### DIFF
--- a/snippets/app/build.gradle.kts
+++ b/snippets/app/build.gradle.kts
@@ -48,7 +48,9 @@ dependencies {
     // [END_EXCLUDE]
 
     // Places and Maps SDKs
+    // [START maps_android_places_upgrade_snippet]
     implementation("com.google.android.libraries.places:places:4.1.0")
+    // [END maps_android_places_upgrade_snippet]
 }
 // [END maps_android_places_install_snippet]
 


### PR DESCRIPTION
It seems like this snippet got accidentally deleted in #802 :

https://github.com/googlemaps-samples/android-places-demos/blob/379f25dc5d00ed38573cbddf3a25f259eee33680/snippets/app/build.gradle#L51-L53

cc @dkhawk 