### PR TITLE
fix: adds back missing region tag in build.gradle.kts file

### DIFF
--- a/snippets/app/build.gradle.kts
+++ b/snippets/app/build.gradle.kts
@@ -48,7 +48,9 @@ dependencies {
     // [END_EXCLUDE]
 
     // Places and Maps SDKs
+    // [START maps_android_places_upgrade_snippet]
     implementation("com.google.android.libraries.places:places:4.1.0")
+    // [END maps_android_places_upgrade_snippet]
 }
 // [END maps_android_places_install_snippet]
 


### PR DESCRIPTION
Adds back region tag that was accidently deleted in https://github.com/googlemaps-samples/android-places-demos/pull/802