### PR TITLE
doc: Add EEA Terms of Service notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ https://github.com/googlemaps/android-places-demos/issues
 Patches are encouraged, and may be submitted according to the instructions in
 CONTRIBUTING.md.
 
+If your billing address is in the European Economic Area, effective on 8 July 2025, the [Google Maps Platform EEA Terms of Service](https://cloud.google.com/terms/maps-platform/eea) will apply to your use of the Services. Functionality varies by region. [Learn more](https://developers.google.com/maps/comms/eea/faq).
+
 License
 -------
 


### PR DESCRIPTION
This PR adds a notice about the Google Maps Platform EEA Terms of Service to the README.md file.