### PR TITLE
Fix: Update demo app UI to support edge-to-edge

### DIFF
--- a/demo-kotlin/app/src/main/AndroidManifest.xml
+++ b/demo-kotlin/app/src/main/AndroidManifest.xml
@@ -28,7 +28,7 @@
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/Theme.AppCompat.Light">
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
 
         <meta-data
             android:name="com.google.android.gms.version"
@@ -50,7 +50,8 @@
 
         <activity
             android:name=".PlaceAutocompleteActivity"
-            android:exported="true" />
+            android:exported="true"
+            />
         <activity
             android:name=".AutocompleteAddressActivity"
             android:exported="true" />
@@ -66,7 +67,7 @@
         <activity
             android:name=".programmatic_autocomplete.ProgrammaticAutocompleteGeocodingActivity"
             android:exported="true"
-            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+            />
 
     </application>
 </manifest>

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/AutocompleteAddressActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/AutocompleteAddressActivity.kt
@@ -31,7 +31,6 @@ import android.widget.Toast
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import com.example.placesdemo.databinding.AutocompleteAddressActivityBinding
 import com.google.android.gms.location.LocationServices
@@ -51,7 +50,7 @@ import androidx.core.view.isGone
 /**
  *  Activity for using Place Autocomplete to assist filling out an address form.
  */
-class AutocompleteAddressActivity : AppCompatActivity(R.layout.autocomplete_address_activity),
+class AutocompleteAddressActivity : BaseActivity(),
     OnMapReadyCallback {
     private lateinit var mapPanel: View
 
@@ -112,8 +111,13 @@ class AutocompleteAddressActivity : AppCompatActivity(R.layout.autocomplete_addr
         super.onCreate(savedInstanceState)
 
         binding = AutocompleteAddressActivityBinding.inflate(layoutInflater)
-        val view = binding.root
-        setContentView(view)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.topBar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.topBar.setNavigationOnClickListener {
+            onBackPressedDispatcher.onBackPressed()
+        }
 
         // Attach an Autocomplete intent to the Address 1 EditText field
         binding.autocompleteAddress1.setOnClickListener(startAutocompleteIntentListener)

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/BaseActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/BaseActivity.kt
@@ -1,0 +1,59 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.example.placesdemo
+
+import android.content.res.Configuration
+import android.os.Bundle
+import android.view.MenuItem
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+
+open class BaseActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        val insetsController = WindowCompat.getInsetsController(window, window.decorView)
+        val isLightTheme = resources.configuration.uiMode and
+                Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_NO
+        insetsController.isAppearanceLightStatusBars = isLightTheme
+
+        // It'''s recommended to apply insets using a listener like this,
+        // especially when dealing with normal views rather than Compose.
+        // This makes sure that the insets are applied after the view is attached
+        // and ensures that the insets are applied correctly every time the
+        // view is laid out.
+        val contentView = findViewById<android.view.View>(android.R.id.content)
+        ViewCompat.setOnApplyWindowInsetsListener(contentView) { view, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            // Apply the insets as padding to the view. Here we'''re setting all of the
+            // dimensions, but apply as appropriate to your layout.
+            // This is where you can adjust your UI based on the cutouts.
+            view.setPadding(insets.left, insets.top, insets.right, insets.bottom)
+
+            // Return CONSUMED if you don'''t want to pass the insets down to the children
+            WindowInsetsCompat.CONSUMED
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            finish()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/CurrentPlaceActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/CurrentPlaceActivity.kt
@@ -35,7 +35,7 @@ import com.google.android.libraries.places.api.net.PlacesClient
 /**
  * Activity to demonstrate [PlacesClient.findCurrentPlace].
  */
-class CurrentPlaceActivity : AppCompatActivity() {
+class CurrentPlaceActivity : BaseActivity() {
     private lateinit var placesClient: PlacesClient
     private lateinit var fieldSelector: FieldSelector
 
@@ -66,6 +66,11 @@ class CurrentPlaceActivity : AppCompatActivity() {
 
         binding = CurrentPlaceActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        setSupportActionBar(binding.topBar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.topBar.setNavigationOnClickListener {
+            onBackPressedDispatcher.onBackPressed()
+        }
 
         // Retrieve a PlacesClient (previously initialized - see MainActivity)
         placesClient = Places.createClient(this)

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/MainActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/MainActivity.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,32 +15,41 @@
  */
 package com.example.placesdemo
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 import android.widget.Button
-import androidx.annotation.IdRes
-import androidx.appcompat.app.AppCompatActivity
+import com.example.placesdemo.databinding.ActivityMainBinding
 import com.example.placesdemo.programmatic_autocomplete.ProgrammaticAutocompleteGeocodingActivity
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseActivity() {
+
+    private lateinit var binding: ActivityMainBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+        setSupportActionBar(binding.topBar)
+        binding.topBar.setNavigationIcon(R.drawable.ic_exit)
+        binding.topBar.setNavigationOnClickListener {
+            finishAffinity() // Closes the app and all parent activities
+        }
 
-        setLaunchActivityClickListener(R.id.autocomplete_button, PlaceAutocompleteActivity::class.java)
-        setLaunchActivityClickListener(R.id.autocomplete_address_button, AutocompleteAddressActivity::class.java)
-        setLaunchActivityClickListener(R.id.programmatic_autocomplete_button, ProgrammaticAutocompleteGeocodingActivity::class.java)
-        setLaunchActivityClickListener(R.id.current_place_button, CurrentPlaceActivity::class.java)
-        setLaunchActivityClickListener(R.id.place_and_photo_button, PlaceDetailsAndPhotosActivity::class.java)
-        setLaunchActivityClickListener(R.id.is_open_button, PlaceIsOpenActivity::class.java)
+        setLaunchActivityClickListener(binding.autocompleteButton, PlaceAutocompleteActivity::class.java)
+        setLaunchActivityClickListener(binding.autocompleteAddressButton, AutocompleteAddressActivity::class.java)
+        setLaunchActivityClickListener(binding.programmaticAutocompleteButton, ProgrammaticAutocompleteGeocodingActivity::class.java)
+        setLaunchActivityClickListener(binding.currentPlaceButton, CurrentPlaceActivity::class.java)
+        setLaunchActivityClickListener(binding.placeAndPhotoButton, PlaceDetailsAndPhotosActivity::class.java)
+        setLaunchActivityClickListener(binding.isOpenButton, PlaceIsOpenActivity::class.java)
     }
 
-    private fun setLaunchActivityClickListener(@IdRes onClickResId: Int, activityClassToLaunch: Class<out AppCompatActivity>) {
-        findViewById<Button>(onClickResId).setOnClickListener {
+    private fun setLaunchActivityClickListener(button: Button, activityClassToLaunch: Class<out Activity>) {
+        button.setOnClickListener {
             val intent = Intent(this@MainActivity, activityClassToLaunch)
             startActivity(intent)
         }
     }
-
 }

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceAutocompleteActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceAutocompleteActivity.kt
@@ -25,7 +25,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.IdRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import com.example.placesdemo.databinding.PlaceAutocompleteActivityBinding
 import com.google.android.gms.common.api.Status
 import com.google.android.gms.maps.model.LatLng
@@ -48,7 +47,7 @@ import com.google.android.libraries.places.widget.model.AutocompleteActivityMode
  * Activity to demonstrate Place Autocomplete (activity widget intent, fragment widget, and
  * [PlacesClient.findAutocompletePredictions]).
  */
-class PlaceAutocompleteActivity : AppCompatActivity() {
+class PlaceAutocompleteActivity : BaseActivity() {
 
     private lateinit var placesClient: PlacesClient
     private lateinit var fieldSelector: FieldSelector
@@ -60,6 +59,12 @@ class PlaceAutocompleteActivity : AppCompatActivity() {
 
         binding = PlaceAutocompleteActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        setSupportActionBar(binding.topBar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.topBar.setNavigationOnClickListener {
+            onBackPressedDispatcher.onBackPressed()
+        }
 
         // Retrieve a PlacesClient (previously initialized - see MainActivity)
         placesClient = Places.createClient(this)

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceDetailsAndPhotosActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceDetailsAndPhotosActivity.kt
@@ -25,7 +25,6 @@ import android.widget.EditText
 import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import com.bumptech.glide.Glide
 import com.example.placesdemo.databinding.PlaceDetailsAndPhotosActivityBinding
 import com.google.android.libraries.places.api.Places
@@ -40,7 +39,7 @@ import com.google.android.libraries.places.api.net.PlacesClient
 /**
  * Activity to demonstrate [PlacesClient.fetchPlace].
  */
-class PlaceDetailsAndPhotosActivity : AppCompatActivity() {
+class PlaceDetailsAndPhotosActivity : BaseActivity() {
     private lateinit var placesClient: PlacesClient
     private lateinit var fieldSelector: FieldSelector
 
@@ -53,6 +52,12 @@ class PlaceDetailsAndPhotosActivity : AppCompatActivity() {
 
         binding = PlaceDetailsAndPhotosActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        setSupportActionBar(binding.topBar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.topBar.setNavigationOnClickListener {
+            onBackPressedDispatcher.onBackPressed()
+        }
 
         // Retrieve a PlacesClient (previously initialized - see MainActivity)
         placesClient = Places.createClient(this)

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/PlaceIsOpenActivity.kt
@@ -25,7 +25,6 @@ import android.view.inputmethod.InputMethodManager
 import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.EditText
-import androidx.appcompat.app.AppCompatActivity
 import com.example.placesdemo.StringUtil.stringify
 import com.example.placesdemo.databinding.PlaceIsOpenActivityBinding
 import com.google.android.gms.tasks.Task
@@ -43,7 +42,7 @@ import java.util.TimeZone.*
 /**
  * Activity to demonstrate [PlacesClient.isOpen].
  */
-class PlaceIsOpenActivity : AppCompatActivity() {
+class PlaceIsOpenActivity : BaseActivity() {
     private val defaultTimeZone = getDefault()
     private val defaultTimeZoneID: String = defaultTimeZone.id
 
@@ -58,6 +57,12 @@ class PlaceIsOpenActivity : AppCompatActivity() {
 
         binding = PlaceIsOpenActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        setSupportActionBar(binding.topBar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        binding.topBar.setNavigationOnClickListener {
+            onBackPressedDispatcher.onBackPressed()
+        }
 
         // Retrieve a PlacesClient (previously initialized - see MainActivity)
         placesClient = Places.createClient( /* context = */this)

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/PlacesDemoApplication.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/PlacesDemoApplication.kt
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//   http://www.apache.org/licenses/LICENSE-2.0
+//   http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteGeocodingActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteGeocodingActivity.kt
@@ -26,6 +26,7 @@ import android.util.Log
 import android.util.TypedValue
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
 import androidx.appcompat.app.AlertDialog
@@ -78,7 +79,8 @@ class ProgrammaticAutocompleteGeocodingActivity : BaseActivity() {
 
     private val handler = Handler(Looper.getMainLooper())
     private val adapter = PlacePredictionAdapter()
-    private val gson = GsonBuilder().registerTypeAdapter(LatLng::class.java, LatLngAdapter()).create()
+    private val gson =
+        GsonBuilder().registerTypeAdapter(LatLng::class.java, LatLngAdapter()).create()
 
     private lateinit var queue: RequestQueue
     private lateinit var placesClient: PlacesClient
@@ -112,7 +114,8 @@ class ProgrammaticAutocompleteGeocodingActivity : BaseActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu, menu)
-        val searchView = menu.findItem(R.id.search).actionView as com.google.android.material.search.SearchView
+        val searchView =
+            menu.findItem(R.id.search).actionView as com.google.android.material.search.SearchView
         initSearchView(searchView)
         return super.onCreateOptionsMenu(menu)
     }
@@ -134,13 +137,18 @@ class ProgrammaticAutocompleteGeocodingActivity : BaseActivity() {
 
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
                 val query = s.toString()
-//                binding.progressBar.isIndeterminate = true
 
                 // Cancel any previous place prediction requests
                 handler.removeCallbacksAndMessages(null)
 
+
                 // Start a new place prediction request after a 300ms delay
-                handler.postDelayed({ getPlacePredictions(query) }, 300)
+                handler.postDelayed({
+                        if (query.isNotEmpty()) binding.progressBar.visibility = View.VISIBLE
+                        getPlacePredictions(query)
+                    },
+                    300
+                )
             }
 
             override fun afterTextChanged(s: Editable?) {
@@ -193,10 +201,11 @@ class ProgrammaticAutocompleteGeocodingActivity : BaseActivity() {
             .addOnSuccessListener { response ->
                 val predictions = response.autocompletePredictions
                 adapter.setPredictions(predictions)
-//                binding.progressBar.isIndeterminate = false
-                binding.resultsViewAnimator.displayedChild = if (predictions.isEmpty() && query.isNotEmpty()) 1 else 0
+                binding.progressBar.visibility = View.INVISIBLE
+                binding.resultsViewAnimator.displayedChild =
+                    if (predictions.isEmpty() && query.isNotEmpty()) 1 else 0
             }.addOnFailureListener { exception: Exception? ->
-//                binding.progressBar.isIndeterminate = false
+                binding.progressBar.visibility = View.INVISIBLE
                 if (exception is ApiException) {
                     Log.e(TAG, "Place not found: ${exception.message}")
                 }
@@ -231,7 +240,8 @@ class ProgrammaticAutocompleteGeocodingActivity : BaseActivity() {
                 }
 
                 // Use Gson to convert the response JSON object to a POJO
-                val result: GeocodingResult = gson.fromJson(results.getString(0), GeocodingResult::class.java)
+                val result: GeocodingResult =
+                    gson.fromJson(results.getString(0), GeocodingResult::class.java)
                 displayDialog(placePrediction, result)
             } catch (e: JSONException) {
                 e.printStackTrace()

--- a/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteGeocodingActivity.kt
+++ b/demo-kotlin/app/src/main/java/com/example/placesdemo/programmatic_autocomplete/ProgrammaticAutocompleteGeocodingActivity.kt
@@ -12,28 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO(issue/224006159): Remove this when the Place Fields Sample is implemented.
 package com.example.placesdemo.programmatic_autocomplete
 
+import com.google.android.material.search.SearchView
+import android.content.Context
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.text.Editable
+import android.text.TextWatcher
 import android.util.Log
+import android.util.TypedValue
 import android.view.Menu
 import android.view.MenuItem
-import android.widget.ProgressBar
-import android.widget.SearchView
-import android.widget.ViewAnimator
+import androidx.annotation.AttrRes
+import androidx.annotation.ColorInt
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import com.android.volley.Request
 import com.android.volley.RequestQueue
 import com.android.volley.toolbox.JsonObjectRequest
 import com.android.volley.toolbox.Volley
+import com.example.placesdemo.BaseActivity
 import com.example.placesdemo.BuildConfig
 import com.example.placesdemo.R
+import com.example.placesdemo.databinding.ActivityProgrammaticAutocompleteBinding
 import com.example.placesdemo.model.GeocodingResult
 import com.google.android.gms.common.api.ApiException
 import com.google.android.gms.maps.model.LatLng
@@ -53,13 +58,23 @@ import org.json.JSONArray
 import org.json.JSONException
 
 /**
+ * Extension function to get a color from the current theme using its attribute resource ID.
+ */
+@ColorInt
+fun Context.getColorFromTheme(@AttrRes colorAttributeResId: Int): Int {
+    val typedValue = TypedValue()
+    theme.resolveAttribute(colorAttributeResId, typedValue, true)
+    return typedValue.data
+}
+
+/**
  * An Activity that demonstrates programmatic as-you-type place predictions. The parameters of the
  * request are currently hard coded in this Activity, to modify these parameters (e.g. location
  * bias, place types, etc.), see [ProgrammaticAutocompleteGeocodingActivity.getPlacePredictions]
  *
  * @see https://developers.google.com/places/android-sdk/autocomplete#get_place_predictions_programmatically
  */
-class ProgrammaticAutocompleteGeocodingActivity : AppCompatActivity() {
+class ProgrammaticAutocompleteGeocodingActivity : BaseActivity() {
 
     private val handler = Handler(Looper.getMainLooper())
     private val adapter = PlacePredictionAdapter()
@@ -68,27 +83,36 @@ class ProgrammaticAutocompleteGeocodingActivity : AppCompatActivity() {
     private lateinit var queue: RequestQueue
     private lateinit var placesClient: PlacesClient
     private var sessionToken: AutocompleteSessionToken? = null
+    private lateinit var binding: ActivityProgrammaticAutocompleteBinding
 
-    private lateinit var viewAnimator: ViewAnimator
-    private lateinit var progressBar: ProgressBar
+    private var colorOnPrimary: Int = 0
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        binding = ActivityProgrammaticAutocompleteBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
-        setContentView(R.layout.activity_programmatic_autocomplete)
-        setSupportActionBar(findViewById(R.id.toolbar))
+        // In your Fragment's onViewCreated or Activity's onCreate
+        val searchBar = binding.searchBar // view.findViewById<SearchBar>(R.id.search_bar)
+        val searchView = binding.searchView // view.findViewById<SearchView>(R.id.search_view)
+
+        // This is the critical line that makes it work!
+        searchView.setupWithSearchBar(searchBar)
+
+        // Now you can initialize your SearchView listeners
+        initSearchView(searchView)
 
         // Initialize members
-        progressBar = findViewById(R.id.progress_bar)
-        viewAnimator = findViewById(R.id.view_animator)
         placesClient = Places.createClient(this)
         queue = Volley.newRequestQueue(this)
         initRecyclerView()
+
+        colorOnPrimary = this.getColorFromTheme(com.google.android.material.R.attr.colorOnPrimary)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.menu, menu)
-        val searchView = menu.findItem(R.id.search).actionView as SearchView
+        val searchView = menu.findItem(R.id.search).actionView as com.google.android.material.search.SearchView
         initSearchView(searchView)
         return super.onCreateOptionsMenu(menu)
     }
@@ -102,31 +126,31 @@ class ProgrammaticAutocompleteGeocodingActivity : AppCompatActivity() {
     }
 
     private fun initSearchView(searchView: SearchView) {
-        searchView.queryHint = getString(R.string.search_a_place)
-        searchView.isIconifiedByDefault = false
-        searchView.isFocusable = true
-        searchView.isIconified = false
-        searchView.requestFocusFromTouch()
-        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
-            override fun onQueryTextSubmit(query: String): Boolean {
-                return false
+        // Add a TextWatcher to the underlying EditText to listen for changes
+        searchView.editText.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+                // No action needed here
             }
 
-            override fun onQueryTextChange(newText: String): Boolean {
-                progressBar.isIndeterminate = true
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                val query = s.toString()
+//                binding.progressBar.isIndeterminate = true
 
                 // Cancel any previous place prediction requests
                 handler.removeCallbacksAndMessages(null)
 
-                // Start a new place prediction request in 300 ms
-                handler.postDelayed({ getPlacePredictions(newText) }, 300)
-                return true
+                // Start a new place prediction request after a 300ms delay
+                handler.postDelayed({ getPlacePredictions(query) }, 300)
+            }
+
+            override fun afterTextChanged(s: Editable?) {
+                // No action needed here
             }
         })
     }
 
     private fun initRecyclerView() {
-        val recyclerView = findViewById<RecyclerView>(R.id.recycler_view)
+        val recyclerView = binding.placeSearchResultsView
         val layoutManager = LinearLayoutManager(this)
         recyclerView.layoutManager = layoutManager
         recyclerView.adapter = adapter
@@ -140,24 +164,24 @@ class ProgrammaticAutocompleteGeocodingActivity : AppCompatActivity() {
 
     /**
      * This method demonstrates the programmatic approach to getting place predictions. The
-     * parameters in this request are currently biased to Kolkata, India.
+     * parameters in this request are currently biased to Boulder, Colorado, USA.
      *
      * @param query the plus code query string (e.g. "GCG2+3M K")
      */
     private fun getPlacePredictions(query: String) {
         // The value of 'bias' biases prediction results to the rectangular region provided
-        // (currently Kolkata). Modify these values to get results for another area. Make sure to
+        // (currently Boulder). Modify these values to get results for another area. Make sure to
         // pass in the appropriate value/s for .setCountries() in the
         // FindAutocompletePredictionsRequest.Builder object as well.
         val bias: LocationBias = RectangularBounds.newInstance(
-            LatLng(22.458744, 88.208162),  // SW lat, lng
-            LatLng(22.730671, 88.524896) // NE lat, lng
+            LatLng(39.9614, -105.3017),  // SW lat, lng (South Boulder)
+            LatLng(40.0953, -105.1843)   // NE lat, lng (Northeast Boulder)
         )
 
         // Create a new programmatic Place Autocomplete request in Places SDK for Android
         val newRequest = FindAutocompletePredictionsRequest.builder()
             .setLocationBias(bias)
-            .setCountries("IN")
+            .setCountries("US")
             .setTypesFilter(listOf(PlaceTypes.ESTABLISHMENT))
             // Session Token only used to link related Place Details call. See https://goo.gle/paaln
             .setSessionToken(sessionToken)
@@ -169,10 +193,10 @@ class ProgrammaticAutocompleteGeocodingActivity : AppCompatActivity() {
             .addOnSuccessListener { response ->
                 val predictions = response.autocompletePredictions
                 adapter.setPredictions(predictions)
-                progressBar.isIndeterminate = false
-                viewAnimator.displayedChild = if (predictions.isEmpty()) 0 else 1
+//                binding.progressBar.isIndeterminate = false
+                binding.resultsViewAnimator.displayedChild = if (predictions.isEmpty() && query.isNotEmpty()) 1 else 0
             }.addOnFailureListener { exception: Exception? ->
-                progressBar.isIndeterminate = false
+//                binding.progressBar.isIndeterminate = false
                 if (exception is ApiException) {
                     Log.e(TAG, "Place not found: ${exception.message}")
                 }
@@ -261,4 +285,3 @@ class ProgrammaticAutocompleteGeocodingActivity : AppCompatActivity() {
         private val TAG = ProgrammaticAutocompleteGeocodingActivity::class.java.simpleName
     }
 }
-

--- a/demo-kotlin/app/src/main/res/drawable/ic_exit.xml
+++ b/demo-kotlin/app/src/main/res/drawable/ic_exit.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorOnPrimary">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>

--- a/demo-kotlin/app/src/main/res/drawable/ic_exit_to_app_black_24dp.xml
+++ b/demo-kotlin/app/src/main/res/drawable/ic_exit_to_app_black_24dp.xml
@@ -1,5 +1,5 @@
 <!--
- Copyright 2020 Google LLC
+ Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -14,13 +14,13 @@
  limitations under the License.
 -->
 
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
-
-  <item
-    android:id="@+id/search"
-    android:icon="@drawable/ic_search_black_24dp"
-    android:title="@string/search"
-    app:actionViewClass="com.google.android.material.search.SearchView"
-    app:showAsAction="collapseActionView|ifRoom" />
-</menu>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M10.09,15.59L11.5,17l5,-5 -5,-5 -1.41,1.41L12.67,11H3v2h9.67l-2.58,2.59zM19,3H5c-1.11,0 -2,0.9 -2,2v4h2V5h14v14H5v-4H3v4c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V5c0,-1.1 -0.9,-2 -2,-2z"/>
+</vector>

--- a/demo-kotlin/app/src/main/res/drawable/ic_search_black_24dp.xml
+++ b/demo-kotlin/app/src/main/res/drawable/ic_search_black_24dp.xml
@@ -18,8 +18,9 @@
         android:width="24dp"
         android:height="24dp"
         android:viewportWidth="24.0"
-        android:viewportHeight="24.0">
+        android:viewportHeight="24.0"
+        android:tint="?attr/colorOnPrimary">
     <path
-        android:fillColor="#FF000000"
+        android:fillColor="@android:color/white"
         android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z"/>
 </vector>

--- a/demo-kotlin/app/src/main/res/layout/activity_main.xml
+++ b/demo-kotlin/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?><!--
- Copyright 2020 Google LLC
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -14,55 +15,81 @@
  limitations under the License.
 -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="@dimen/spacing_large"
-    android:orientation="vertical"
     tools:context=".MainActivity">
 
-    <Button
-        android:id="@+id/autocomplete_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_small"
-        android:text="@string/autocomplete_button" />
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/app_name"
+        app:titleTextColor="?attr/colorOnPrimary" />
 
-    <Button
-        android:id="@+id/autocomplete_address_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_small"
-        android:text="@string/autocomplete_address_button" />
+    <ScrollView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
 
-    <Button
-        android:id="@+id/programmatic_autocomplete_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_small"
-        android:text="@string/programmatic_autocomplete_geocoding" />
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="@dimen/spacing_large">
 
-    <Button
-        android:id="@+id/current_place_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_small"
-        android:text="@string/current_place_button" />
+            <Button
+                android:id="@+id/autocomplete_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/spacing_small"
+                android:text="@string/autocomplete_button" />
 
-    <Button
-        android:id="@+id/place_and_photo_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_small"
-        android:text="@string/place_and_photo_button" />
+            <Button
+                android:id="@+id/autocomplete_address_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/spacing_small"
+                android:text="@string/autocomplete_address_button" />
 
-    <Button
-        android:id="@+id/is_open_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="@dimen/spacing_small"
-        android:text="@string/main_isOpenButtonText" />
+            <Button
+                android:id="@+id/programmatic_autocomplete_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/spacing_small"
+                android:text="@string/programmatic_autocomplete_geocoding" />
 
-</LinearLayout>
+            <Button
+                android:id="@+id/current_place_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/spacing_small"
+                android:text="@string/current_place_button" />
 
+            <Button
+                android:id="@+id/place_and_photo_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/spacing_small"
+                android:text="@string/place_and_photo_button" />
+
+            <Button
+                android:id="@+id/is_open_button"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/spacing_small"
+                android:text="@string/main_isOpenButtonText" />
+
+        </LinearLayout>
+    </ScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/demo-kotlin/app/src/main/res/layout/activity_programmatic_autocomplete.xml
+++ b/demo-kotlin/app/src/main/res/layout/activity_programmatic_autocomplete.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright 2020 Google LLC
+ Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,51 +15,69 @@
  limitations under the License.
 -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  android:layout_width="match_parent"
-  android:layout_height="match_parent"
-  android:orientation="vertical"
-  tools:context=".programmatic_autocomplete.ProgrammaticAutocompleteGeocodingActivity">
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".programmatic_autocomplete.ProgrammaticAutocompleteGeocodingActivity"
+    >
 
   <com.google.android.material.appbar.AppBarLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content">
-
-    <androidx.appcompat.widget.Toolbar
-      android:id="@+id/toolbar"
       android:layout_width="match_parent"
-      android:layout_height="?attr/actionBarSize"
-      android:background="?attr/colorPrimary" />
-
-    <ProgressBar
-      android:id="@+id/progress_bar"
-      style="@style/Widget.AppCompat.ProgressBar.Horizontal"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginTop="-7dp"
-      android:layout_marginBottom="-7dp" />
-
+      android:layout_height="wrap_content">
+    <com.google.android.material.search.SearchBar
+        android:id="@+id/search_bar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="@string/search_a_place" />
   </com.google.android.material.appbar.AppBarLayout>
 
-  <ViewAnimator
-    android:id="@+id/view_animator"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <TextView
+  <androidx.core.widget.NestedScrollView
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:layout_margin="16dp"
-      android:gravity="center"
-      android:lineSpacingMultiplier="1.15"
-      android:text="@string/programmatic_place_predictions_instructions"
-      android:textSize="20sp" />
+      app:layout_behavior="@string/appbar_scrolling_view_behavior">
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="16dp"
+        android:gravity="center"
+        android:lineSpacingMultiplier="1.15"
+        android:text="@string/programmatic_place_predictions_instructions"
+        android:textSize="20sp" />
 
-    <androidx.recyclerview.widget.RecyclerView
-      android:id="@+id/recycler_view"
+  </androidx.core.widget.NestedScrollView>
+
+  <com.google.android.material.search.SearchView
+      android:id="@+id/search_view"
       android:layout_width="match_parent"
-      android:layout_height="match_parent" />
-  </ViewAnimator>
+      android:layout_height="match_parent"
+      android:hint="@string/search_a_place"
+      app:layout_anchor="@id/search_bar">
 
-</LinearLayout>
+    <ViewAnimator
+        android:id="@+id/results_view_animator"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+      <androidx.recyclerview.widget.RecyclerView
+          android:id="@+id/place_search_results_view"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent" />
+
+      <TextView
+          android:id="@+id/search_error"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+          android:layout_margin="16dp"
+          android:gravity="center"
+          android:lineSpacingMultiplier="1.15"
+          android:text="@string/programmatic_place_predictions_no_matches"
+          android:textSize="20sp"
+          android:visibility="gone" />
+
+    </ViewAnimator>
+
+  </com.google.android.material.search.SearchView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/demo-kotlin/app/src/main/res/layout/activity_programmatic_autocomplete.xml
+++ b/demo-kotlin/app/src/main/res/layout/activity_programmatic_autocomplete.xml
@@ -56,6 +56,20 @@
       android:hint="@string/search_a_place"
       app:layout_anchor="@id/search_bar">
 
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        style="?android:attr/progressBarStyleHorizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:paddingHorizontal="0dp"
+        android:paddingVertical="0dp"
+        android:layout_marginBottom="-8dp"
+        android:layout_marginTop="-6dp"
+        android:visibility="invisible"
+        tools:visibility="invisible"
+        />
+
     <ViewAnimator
         android:id="@+id/results_view_animator"
         android:layout_width="match_parent"
@@ -67,7 +81,6 @@
           android:layout_height="match_parent" />
 
       <TextView
-          android:id="@+id/search_error"
           android:layout_width="match_parent"
           android:layout_height="match_parent"
           android:layout_margin="16dp"

--- a/demo-kotlin/app/src/main/res/layout/autocomplete_address_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/autocomplete_address_activity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright 2021 Google LLC
+ Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,158 +15,173 @@
  limitations under the License.
 -->
 
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="@dimen/spacing_large"
     tools:context=".AutocompleteAddressActivity">
 
-  <LinearLayout
-      android:id="@+id/autocomplete_scroll_container"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical">
+  <com.google.android.material.appbar.MaterialToolbar
+      android:id="@+id/top_bar"
+      style="@style/Widget.MaterialComponents.Toolbar.Primary"
+      android:layout_width="0dp"
+      android:layout_height="?attr/actionBarSize"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:title="@string/autocomplete_address_button"
+      app:titleTextColor="?attr/colorOnPrimary" />
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/autocomplete_address1_label"/>
-
-    <com.example.placesdemo.model.AutocompleteEditText
-        android:id="@+id/autocomplete_address1"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:autofillHints=""
-        android:hint="@string/autocomplete_address1_label"
-        android:imeOptions="actionNext"
-        android:inputType="text"/>
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/autocomplete_address2_label"/>
-
-    <EditText
-        android:id="@+id/autocomplete_address2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:autofillHints=""
-        android:hint="@string/autocomplete_address2_label"
-        android:imeOptions="actionNext"
-        android:inputType="text"/>
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/autocomplete_city_label"/>
-
-    <EditText
-        android:id="@+id/autocomplete_city"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:autofillHints=""
-        android:hint="@string/autocomplete_city_label"
-        android:imeOptions="actionNext"
-        android:inputType="text"/>
+  <ScrollView
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      app:layout_constraintTop_toBottomOf="@+id/top_bar"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent">
 
     <LinearLayout
+        android:id="@+id/autocomplete_scroll_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:baselineAligned="false">
-
-      <LinearLayout
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          android:layout_weight="1"
-          android:orientation="vertical">
+        android:padding="@dimen/spacing_large"
+        android:orientation="vertical">
 
       <TextView
-          android:layout_width="match_parent"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:text="@string/autocomplete_state_label"/>
+          android:text="@string/autocomplete_address1_label" />
 
-      <EditText
-          android:id="@+id/autocomplete_state"
+      <com.example.placesdemo.model.AutocompleteEditText
+          android:id="@+id/autocomplete_address1"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
           android:autofillHints=""
-          android:hint="@string/autocomplete_state_label"
+          android:hint="@string/autocomplete_address1_label"
           android:imeOptions="actionNext"
-          android:inputType="textCapCharacters"/>
+          android:inputType="text" />
 
-      </LinearLayout>
+      <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/autocomplete_address2_label" />
+
+      <EditText
+          android:id="@+id/autocomplete_address2"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:autofillHints=""
+          android:hint="@string/autocomplete_address2_label"
+          android:imeOptions="actionNext"
+          android:inputType="text" />
+
+      <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/autocomplete_city_label" />
+
+      <EditText
+          android:id="@+id/autocomplete_city"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:autofillHints=""
+          android:hint="@string/autocomplete_city_label"
+          android:imeOptions="actionNext"
+          android:inputType="text" />
 
       <LinearLayout
-          android:layout_width="0dp"
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_weight="1"
-          android:orientation="vertical">
+          android:baselineAligned="false"
+          android:orientation="horizontal">
 
-        <TextView
-            android:layout_width="match_parent"
+        <LinearLayout
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="@string/autocomplete_postal_label"/>
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+          <TextView
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:text="@string/autocomplete_state_label" />
+
+          <EditText
+              android:id="@+id/autocomplete_state"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:autofillHints=""
+              android:hint="@string/autocomplete_state_label"
+              android:imeOptions="actionNext"
+              android:inputType="textCapCharacters" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+          <TextView
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:text="@string/autocomplete_postal_label" />
+
+          <EditText
+              android:id="@+id/autocomplete_postal"
+              android:layout_width="match_parent"
+              android:layout_height="0dp"
+              android:layout_weight="1"
+              android:autofillHints=""
+              android:hint="@string/autocomplete_postal_label"
+              android:imeOptions="actionNext"
+              android:inputType="number" />
+        </LinearLayout>
+      </LinearLayout>
+
+      <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/autocomplete_country_label" />
 
       <EditText
-          android:id="@+id/autocomplete_postal"
+          android:id="@+id/autocomplete_country"
           android:layout_width="match_parent"
-          android:layout_height="0dp"
-          android:layout_weight="1"
+          android:layout_height="wrap_content"
           android:autofillHints=""
-          android:hint="@string/autocomplete_postal_label"
+          android:hint="@string/autocomplete_country_label"
           android:imeOptions="actionNext"
-          android:inputType="number"/>
-      </LinearLayout>
+          android:inputType="text" />
+
+      <CheckBox
+          android:id="@+id/checkbox_proximity"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/autocomplete_proximity_check" />
+
+      <ViewStub
+          android:id="@+id/stub_map"
+          android:inflatedId="@+id/panel_map"
+          android:layout="@layout/autocomplete_address_map"
+          android:layout_width="match_parent"
+          android:layout_height="200dp"
+          android:layout_gravity="bottom" />
+
+      <Button
+          android:id="@+id/autocomplete_save_button"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:text="@string/autocomplete_save_button" />
+
+      <Button
+          android:id="@+id/autocomplete_reset_button"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:background="@android:color/transparent"
+          android:text="@string/autocomplete_reset_button" />
     </LinearLayout>
+  </ScrollView>
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/autocomplete_country_label"/>
-
-    <EditText
-        android:id="@+id/autocomplete_country"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:autofillHints=""
-        android:hint="@string/autocomplete_country_label"
-        android:imeOptions="actionNext"
-        android:inputType="text"/>
-
-    <!-- Proximity check option provided for development testing convenience.
-     User would typically not control this option. -->
-    <CheckBox android:id="@+id/checkbox_proximity"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/autocomplete_proximity_check"/>
-
-    <!-- The map for visual confirmation of the selected address -->
-    <!-- Stub to only load the map after Autocomplete prediction selection -->
-    <ViewStub
-        android:id="@+id/stub_map"
-        android:inflatedId="@+id/panel_map"
-        android:layout="@layout/autocomplete_address_map"
-        android:layout_width="match_parent"
-        android:layout_height="200dp"
-        android:layout_gravity="bottom" />
-
-    <Button
-        android:id="@+id/autocomplete_save_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/autocomplete_save_button"/>
-
-    <!-- Reset button provided for development testing convenience. Not recommended for user-facing
-    forms due to risk of mis-click when aiming for Submit button. -->
-    <Button
-        android:id="@+id/autocomplete_reset_button"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:background="@android:color/transparent"
-        android:text="@string/autocomplete_reset_button"/>
-  </LinearLayout>
-</ScrollView>
-
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/demo-kotlin/app/src/main/res/layout/current_place_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/current_place_activity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright 2020 Google LLC
+ Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,66 +15,85 @@
  limitations under the License.
 -->
 
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="@dimen/spacing_large"
     tools:context=".CurrentPlaceActivity">
 
-  <LinearLayout
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical">
+  <com.google.android.material.appbar.MaterialToolbar
+      android:id="@+id/top_bar"
+      style="@style/Widget.MaterialComponents.Toolbar.Primary"
+      android:layout_width="0dp"
+      android:layout_height="?attr/actionBarSize"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:title="@string/current_place_button"
+      app:titleTextColor="?attr/colorOnPrimary" />
+
+  <ScrollView
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      app:layout_constraintTop_toBottomOf="@+id/top_bar"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:padding="@dimen/spacing_large"
+        android:orientation="vertical">
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal">
+
+        <CheckBox
+            android:id="@+id/use_custom_fields"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/use_custom_fields" />
+
+        <TextView
+            android:id="@+id/custom_fields_list"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+
+      </LinearLayout>
+
+      <Button
+          android:id="@+id/find_current_place_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/find_current_place_button" />
 
       <CheckBox
-          android:id="@+id/use_custom_fields"
-          android:layout_width="0dp"
+          android:id="@+id/display_raw_results"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_weight="1"
-          android:text="@string/use_custom_fields"/>
+          android:checked="false"
+          android:text="@string/display_raw_results" />
+
+      <ProgressBar
+          android:id="@+id/loading"
+          style="?android:attr/progressBarStyleSmall"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:visibility="invisible" />
 
       <TextView
-          android:id="@+id/custom_fields_list"
-          android:layout_width="0dp"
+          android:id="@+id/response"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_weight="1"/>
+          android:textIsSelectable="true" />
 
     </LinearLayout>
+  </ScrollView>
 
-    <Button
-        android:id="@+id/find_current_place_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/find_current_place_button"/>
-
-    <CheckBox
-        android:id="@+id/display_raw_results"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:checked="false"
-        android:text="@string/display_raw_results"/>
-
-    <ProgressBar
-        android:id="@+id/loading"
-        style="?android:attr/progressBarStyleSmall"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="invisible"/>
-
-    <TextView
-        android:id="@+id/response"
-        android:textIsSelectable="true"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
-
-  </LinearLayout>
-
-</ScrollView>
-
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/demo-kotlin/app/src/main/res/layout/place_autocomplete_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/place_autocomplete_activity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright 2020 Google LLC
+ Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,251 +15,266 @@
  limitations under the License.
 -->
 
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="@dimen/spacing_large"
     tools:context=".PlaceAutocompleteActivity">
 
-  <LinearLayout
-      android:id="@+id/autocomplete_scroll_container"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical">
+  <com.google.android.material.appbar.MaterialToolbar
+      android:id="@+id/top_bar"
+      style="@style/Widget.MaterialComponents.Toolbar.Primary"
+      android:layout_width="0dp"
+      android:layout_height="?attr/actionBarSize"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:title="@string/autocomplete_button"
+      app:titleTextColor="?attr/colorOnPrimary" />
 
-    <!--Autocomplete parameters-->
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/autocomplete_location_origin_label"/>
-
-    <EditText
-        android:id="@+id/autocomplete_location_origin"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/autocomplete_location_origin_hint"
-        android:autofillHints=""
-        android:imeOptions="actionNext"
-        android:inputType="numberDecimal|numberSigned"
-        android:digits="0123456789.,- "
-        />
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/autocomplete_location_bias_label"/>
+  <ScrollView
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      app:layout_constraintTop_toBottomOf="@+id/top_bar"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent">
 
     <LinearLayout
+        android:id="@+id/autocomplete_scroll_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-      <EditText
-          android:id="@+id/autocomplete_location_bias_south_west"
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          android:minHeight="48dp"
-          android:layout_weight="1"
-          android:hint="@string/autocomplete_location_south_west_hint"
-          android:autofillHints=""
-          android:imeOptions="actionNext"
-          android:inputType="numberDecimal|numberSigned"
-          android:digits="0123456789.,- "
-          />
-
-      <EditText
-          android:id="@+id/autocomplete_location_bias_north_east"
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          android:layout_weight="1"
-          android:hint="@string/autocomplete_location_north_east_hint"
-          android:autofillHints=""
-          android:imeOptions="actionNext"
-          android:inputType="numberDecimal|numberSigned"
-          android:digits="0123456789.,- "
-          />
-    </LinearLayout>
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/autocomplete_location_restriction_label"/>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-      <EditText
-          android:id="@+id/autocomplete_location_restriction_south_west"
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          android:minHeight="48dp"
-          android:layout_weight="1"
-          android:hint="@string/autocomplete_location_south_west_hint"
-          android:autofillHints=""
-          android:imeOptions="actionNext"
-          android:inputType="numberDecimal|numberSigned"
-          android:digits="0123456789.,- "
-          />
-
-      <EditText
-          android:id="@+id/autocomplete_location_restriction_north_east"
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          android:layout_weight="1"
-          android:hint="@string/autocomplete_location_north_east_hint"
-          android:autofillHints=""
-          android:imeOptions="actionNext"
-          android:inputType="numberDecimal|numberSigned"
-          android:digits="0123456789.,- "
-          />
-    </LinearLayout>
-
-    <EditText
-        android:id="@+id/autocomplete_query"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/autocomplete_query_hint"
-        android:autofillHints=""
-        android:imeOptions="actionNext"
-        android:inputType="text"/>
-
-    <!-- Autocomplete fragment only -->
-    <EditText
-        android:id="@+id/autocomplete_hint"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/autocomplete_hint_hint"
-        android:autofillHints=""
-        android:imeOptions="actionNext"
-        android:inputType="text"/>
-
-    <EditText
-        android:id="@+id/autocomplete_country"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/autocomplete_country_hint"
-        android:autofillHints=""
-        android:imeOptions="actionNext"
-        android:inputType="text"/>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:padding="@dimen/spacing_large"
         android:orientation="vertical">
 
-      <CheckBox
-          android:id="@+id/autocomplete_use_types_filter_checkbox"
+      <!--Autocomplete parameters-->
+      <TextView
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:minHeight="48dp"
-          android:checked="false"
-          android:text="@string/autocomplete_use_types_filter"/>
+          android:text="@string/autocomplete_location_origin_label" />
 
       <EditText
-          android:id="@+id/autocomplete_types_filter_edittext"
-          android:autofillHints=""
-          android:enabled="false"
+          android:id="@+id/autocomplete_location_origin"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:hint="@string/autocomplete_types_filter_hint"
-          android:inputType="text"/>
-
-    </LinearLayout>
-
-    <!-- Autocomplete predictions only -->
-    <CheckBox
-        android:id="@+id/autocomplete_use_session_token"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:minHeight="48dp"
-        android:checked="false"
-        android:text="@string/autocomplete_use_session_token"/>
-
-    <!-- Autocomplete activity only -->
-    <CheckBox
-        android:id="@+id/autocomplete_activity_overlay_mode"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:minHeight="48dp"
-        android:checked="false"
-        android:text="@string/autocomplete_activity_overlay_mode"/>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
-
-      <CheckBox
-          android:id="@+id/use_custom_fields"
-          android:layout_width="wrap_content"
-          android:layout_height="wrap_content"
-          android:minHeight="48dp"
-          android:text="@string/use_custom_fields"/>
+          android:autofillHints=""
+          android:digits="0123456789.,- "
+          android:hint="@string/autocomplete_location_origin_hint"
+          android:imeOptions="actionNext"
+          android:inputType="numberDecimal|numberSigned" />
 
       <TextView
-          android:id="@+id/custom_fields_list"
-          android:layout_width="0dp"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_weight="1"/>
+          android:text="@string/autocomplete_location_bias_label" />
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/autocomplete_location_bias_south_west"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:autofillHints=""
+            android:digits="0123456789.,- "
+            android:hint="@string/autocomplete_location_south_west_hint"
+            android:imeOptions="actionNext"
+            android:inputType="numberDecimal|numberSigned"
+            android:minHeight="48dp" />
+
+        <EditText
+            android:id="@+id/autocomplete_location_bias_north_east"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:autofillHints=""
+            android:digits="0123456789.,- "
+            android:hint="@string/autocomplete_location_north_east_hint"
+            android:imeOptions="actionNext"
+            android:inputType="numberDecimal|numberSigned" />
+      </LinearLayout>
+
+      <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/autocomplete_location_restriction_label" />
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/autocomplete_location_restriction_south_west"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:autofillHints=""
+            android:digits="0123456789.,- "
+            android:hint="@string/autocomplete_location_south_west_hint"
+            android:imeOptions="actionNext"
+            android:inputType="numberDecimal|numberSigned"
+            android:minHeight="48dp" />
+
+        <EditText
+            android:id="@+id/autocomplete_location_restriction_north_east"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:autofillHints=""
+            android:digits="0123456789.,- "
+            android:hint="@string/autocomplete_location_north_east_hint"
+            android:imeOptions="actionNext"
+            android:inputType="numberDecimal|numberSigned" />
+      </LinearLayout>
+
+      <EditText
+          android:id="@+id/autocomplete_query"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:autofillHints=""
+          android:hint="@string/autocomplete_query_hint"
+          android:imeOptions="actionNext"
+          android:inputType="text" />
+
+      <!-- Autocomplete fragment only -->
+      <EditText
+          android:id="@+id/autocomplete_hint"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:autofillHints=""
+          android:hint="@string/autocomplete_hint_hint"
+          android:imeOptions="actionNext"
+          android:inputType="text" />
+
+      <EditText
+          android:id="@+id/autocomplete_country"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:autofillHints=""
+          android:hint="@string/autocomplete_country_hint"
+          android:imeOptions="actionNext"
+          android:inputType="text" />
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="vertical">
+
+        <CheckBox
+            android:id="@+id/autocomplete_use_types_filter_checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="false"
+            android:minHeight="48dp"
+            android:text="@string/autocomplete_use_types_filter" />
+
+        <EditText
+            android:id="@+id/autocomplete_types_filter_edittext"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:autofillHints=""
+            android:enabled="false"
+            android:hint="@string/autocomplete_types_filter_hint"
+            android:inputType="text" />
+
+      </LinearLayout>
+
+      <!-- Autocomplete predictions only -->
+      <CheckBox
+          android:id="@+id/autocomplete_use_session_token"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:checked="false"
+          android:minHeight="48dp"
+          android:text="@string/autocomplete_use_session_token" />
+
+      <!-- Autocomplete activity only -->
+      <CheckBox
+          android:id="@+id/autocomplete_activity_overlay_mode"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:checked="false"
+          android:minHeight="48dp"
+          android:text="@string/autocomplete_activity_overlay_mode" />
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal">
+
+        <CheckBox
+            android:id="@+id/use_custom_fields"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:text="@string/use_custom_fields" />
+
+        <TextView
+            android:id="@+id/custom_fields_list"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+
+      </LinearLayout>
+
+      <Button
+          android:id="@+id/fetch_autocomplete_predictions_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/fetch_autocomplete_predictions_button" />
+
+      <Button
+          android:id="@+id/autocomplete_activity_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/autocomplete_activity_button" />
+
+      <!-- Autocomplete support fragment -->
+      <TextView
+          android:id="@+id/autocomplete_support_fragment_text_label"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/autocomplete_support_fragment_text_label" />
+
+      <androidx.fragment.app.FragmentContainerView
+          android:id="@+id/autocomplete_support_fragment"
+          android:name="com.google.android.libraries.places.widget.AutocompleteSupportFragment"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          tools:layout="@layout/places_autocomplete_fragment" />
+
+      <Button
+          android:id="@+id/autocomplete_support_fragment_update_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/autocomplete_support_fragment_update_button" />
+
+      <!-- Results -->
+      <CheckBox
+          android:id="@+id/display_raw_results"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:checked="false"
+          android:text="@string/display_raw_results" />
+
+      <ProgressBar
+          android:id="@+id/loading"
+          style="?android:attr/progressBarStyleSmall"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:visibility="invisible" />
+
+      <TextView
+          android:id="@+id/response"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:textIsSelectable="true" />
 
     </LinearLayout>
-
-    <Button
-        android:id="@+id/fetch_autocomplete_predictions_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/fetch_autocomplete_predictions_button"/>
-
-    <Button
-        android:id="@+id/autocomplete_activity_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/autocomplete_activity_button"/>
-
-    <!-- Autocomplete support fragment -->
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/autocomplete_support_fragment_text_label"
-        android:text="@string/autocomplete_support_fragment_text_label"/>
-
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/autocomplete_support_fragment"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:name="com.google.android.libraries.places.widget.AutocompleteSupportFragment"
-        tools:layout="@layout/places_autocomplete_fragment" />
-
-    <Button
-        android:id="@+id/autocomplete_support_fragment_update_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/autocomplete_support_fragment_update_button"/>
-
-    <!-- Results -->
-    <CheckBox
-        android:id="@+id/display_raw_results"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:checked="false"
-        android:text="@string/display_raw_results"/>
-
-    <ProgressBar
-        android:id="@+id/loading"
-        style="?android:attr/progressBarStyleSmall"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:visibility="invisible"/>
-
-    <TextView
-        android:id="@+id/response"
-        android:textIsSelectable="true"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
-
-  </LinearLayout>
-</ScrollView>
+  </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/demo-kotlin/app/src/main/res/layout/place_details_and_photos_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/place_details_and_photos_activity.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
- Copyright 2020 Google LLC
+ Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -15,177 +15,196 @@
  limitations under the License.
 -->
 
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="@dimen/spacing_large"
     tools:context=".PlaceDetailsAndPhotosActivity">
 
-  <LinearLayout
-      android:id="@+id/place_scroll_container"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical">
+  <com.google.android.material.appbar.MaterialToolbar
+      android:id="@+id/top_bar"
+      style="@style/Widget.MaterialComponents.Toolbar.Primary"
+      android:layout_width="0dp"
+      android:layout_height="?attr/actionBarSize"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:title="@string/place_and_photo_button"
+      app:titleTextColor="?attr/colorOnPrimary" />
 
-    <EditText
-        android:id="@+id/place_id_field"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/place_id_field_hint"
-        android:autofillHints=""
-        android:imeOptions="actionGo"
-        android:inputType="text"
-        android:text="@string/place_id_default"/>
-
-    <CheckBox
-        android:id="@+id/fetch_photo_checkbox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:checked="true"
-        android:text="@string/fetch_photo_checkbox"/>
-
-    <CheckBox
-        android:id="@+id/fetch_icon_checkbox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:checked="false"
-        android:text="@string/fetch_icon_checkbox"/>
+  <ScrollView
+      android:layout_width="0dp"
+      android:layout_height="0dp"
+      app:layout_constraintTop_toBottomOf="@+id/top_bar"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent">
 
     <LinearLayout
+        android:id="@+id/place_scroll_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:padding="@dimen/spacing_large"
+        android:orientation="vertical">
 
       <EditText
-          android:id="@+id/photo_max_width"
-          android:layout_width="0dp"
+          android:id="@+id/place_id_field"
+          android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_weight="1"
-          android:hint="@string/photo_max_width_hint"
           android:autofillHints=""
-          android:imeOptions="actionNext"
-          android:inputType="number"/>
-
-      <EditText
-          android:id="@+id/photo_max_height"
-          android:layout_width="0dp"
-          android:layout_height="wrap_content"
-          android:layout_weight="1"
-          android:hint="@string/photo_max_height_hint"
-          android:autofillHints=""
-          android:imeOptions="actionNext"
-          android:inputType="number"/>
-
-    </LinearLayout>
-
-    <CheckBox
-        android:id="@+id/use_custom_photo_reference"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:checked="false"
-        android:text="@string/use_custom_photo_reference"/>
-
-    <EditText
-        android:id="@+id/custom_photo_reference"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:hint="@string/custom_photo_reference_hint"
-        android:autofillHints=""
-        android:imeOptions="actionNext"
-        android:inputType="text"/>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+          android:hint="@string/place_id_field_hint"
+          android:imeOptions="actionGo"
+          android:inputType="text"
+          android:text="@string/place_id_default" />
 
       <CheckBox
-          android:id="@+id/use_custom_fields"
-          android:layout_width="0dp"
+          android:id="@+id/fetch_photo_checkbox"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_weight="1"
-          android:text="@string/use_custom_fields"/>
+          android:checked="true"
+          android:text="@string/fetch_photo_checkbox" />
+
+      <CheckBox
+          android:id="@+id/fetch_icon_checkbox"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:checked="false"
+          android:text="@string/fetch_icon_checkbox" />
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/photo_max_width"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:autofillHints=""
+            android:hint="@string/photo_max_width_hint"
+            android:imeOptions="actionNext"
+            android:inputType="number" />
+
+        <EditText
+            android:id="@+id/photo_max_height"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:autofillHints=""
+            android:hint="@string/photo_max_height_hint"
+            android:imeOptions="actionNext"
+            android:inputType="number" />
+
+      </LinearLayout>
+
+      <CheckBox
+          android:id="@+id/use_custom_photo_reference"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:checked="false"
+          android:text="@string/use_custom_photo_reference" />
+
+      <EditText
+          android:id="@+id/custom_photo_reference"
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:autofillHints=""
+          android:hint="@string/custom_photo_reference_hint"
+          android:imeOptions="actionNext"
+          android:inputType="text" />
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal">
+
+        <CheckBox
+            android:id="@+id/use_custom_fields"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/use_custom_fields" />
+
+        <TextView
+            android:id="@+id/custom_fields_list"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1" />
+
+      </LinearLayout>
+
+      <Button
+          android:id="@+id/fetch_place_and_photo_button"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:text="@string/fetch_place_and_photo_button" />
+
+      <CheckBox
+          android:id="@+id/display_raw_results"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:checked="false"
+          android:text="@string/display_raw_results" />
 
       <TextView
-          android:id="@+id/custom_fields_list"
-          android:layout_width="0dp"
+          android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_weight="1"/>
-
-    </LinearLayout>
-
-    <Button
-        android:id="@+id/fetch_place_and_photo_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/fetch_place_and_photo_button"/>
-
-    <CheckBox
-        android:id="@+id/display_raw_results"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:checked="false"
-        android:text="@string/display_raw_results"/>
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/icon_with_background"/>
-
-    <ImageView
-        android:id="@+id/icon"
-        android:contentDescription="@string/icon_view_image_content_description"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:background="@color/material_grey_300"
-        android:padding="4dp"
-        android:minHeight="48dp"
-        android:minWidth="48dp"
-        app:tint="@android:color/white" />
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/place_photo"/>
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+          android:text="@string/icon_with_background" />
 
       <ImageView
-          android:id="@+id/photo"
+          android:id="@+id/icon"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           android:background="@color/material_grey_300"
+          android:contentDescription="@string/icon_view_image_content_description"
+          android:minWidth="48dp"
           android:minHeight="48dp"
-          android:minWidth="48dp"/>
+          android:padding="4dp"
+          app:tint="@android:color/white" />
 
-      <ProgressBar
-          android:id="@+id/loading"
-          style="?android:attr/progressBarStyleSmall"
+      <TextView
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:visibility="invisible"/>
+          android:text="@string/place_photo" />
+
+      <LinearLayout
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          android:orientation="horizontal">
+
+        <ImageView
+            android:id="@+id/photo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:background="@color/material_grey_300"
+            android:minWidth="48dp"
+            android:minHeight="48dp" />
+
+        <ProgressBar
+            android:id="@+id/loading"
+            style="?android:attr/progressBarStyleSmall"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="invisible" />
+
+      </LinearLayout>
+
+      <TextView
+          android:id="@+id/photo_metadata"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:textIsSelectable="true" />
+
+      <TextView
+          android:id="@+id/response"
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:freezesText="true"
+          android:textIsSelectable="true" />
 
     </LinearLayout>
+  </ScrollView>
 
-    <TextView
-        android:id="@+id/photo_metadata"
-        android:textIsSelectable="true"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
-
-    <TextView
-        android:id="@+id/response"
-        android:freezesText="true"
-        android:textIsSelectable="true"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"/>
-
-  </LinearLayout>
-
-</ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/demo-kotlin/app/src/main/res/layout/place_is_open_activity.xml
+++ b/demo-kotlin/app/src/main/res/layout/place_is_open_activity.xml
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?><!--
- Copyright 2020 Google LLC
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2025 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -14,153 +15,172 @@
  limitations under the License.
 -->
 
-
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_margin="@dimen/spacing_large"
     tools:context=".PlaceIsOpenActivity">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="10dp"
-        android:orientation="vertical">
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/top_bar"
+        style="@style/Widget.MaterialComponents.Toolbar.Primary"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:title="@string/main_isOpenButtonText"
+        app:titleTextColor="?attr/colorOnPrimary" />
 
-        <EditText
-            android:id="@+id/editText_placeId"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:autofillHints=""
-            android:hint="@string/isOpen_place_id_hint"
-            android:imeOptions="actionGo"
-            android:inputType="text"
-            android:minHeight="48dp"
-            android:text="@string/isOpen_default_place_id" />
+    <ScrollView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@+id/top_bar"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:orientation="vertical"
+            android:padding="10dp">
 
-            <CheckBox
-                android:id="@+id/checkBox_use_custom_fields"
-                android:layout_width="0dp"
+            <EditText
+                android:id="@+id/editText_placeId"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
+                android:autofillHints=""
+                android:hint="@string/isOpen_place_id_hint"
+                android:imeOptions="actionGo"
+                android:inputType="text"
                 android:minHeight="48dp"
-                android:text="@string/isOpen_use_custom_fields_text" />
+                android:text="@string/isOpen_default_place_id" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <CheckBox
+                    android:id="@+id/checkBox_use_custom_fields"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:minHeight="48dp"
+                    android:text="@string/isOpen_use_custom_fields_text" />
+
+                <TextView
+                    android:id="@+id/textView_custom_fields_list"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1" />
+
+            </LinearLayout>
 
             <TextView
-                android:id="@+id/textView_custom_fields_list"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1" />
+                android:minHeight="48dp"
+                android:text="@string/isOpen_use_custom_time_hint" />
 
-        </LinearLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:weightSum="10">
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="48dp"
-            android:text="@string/isOpen_use_custom_time_hint" />
+                <TextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="3"
+                    android:minHeight="48dp"
+                    android:text="@string/isOpen_spinner_description" />
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            android:weightSum="10">
+                <Spinner
+                    android:id="@+id/spinner_time_zones"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="7"
+                    android:minHeight="48dp"
+                    android:padding="10dp" />
+
+            </LinearLayout>
+
+            <EditText
+                android:id="@+id/editText_is_open_date"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:autofillHints=""
+                android:clickable="false"
+                android:cursorVisible="false"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:hint="@string/isOpen_date_hint"
+                android:inputType="date"
+                android:longClickable="false"
+                android:minHeight="48dp" />
+
+            <EditText
+                android:id="@+id/editText_is_open_time"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:autofillHints=""
+                android:clickable="false"
+                android:cursorVisible="false"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:hint="@string/isOpen_time_hint"
+                android:inputType="time"
+                android:longClickable="false"
+                android:minHeight="48dp" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/button_fetchPlace"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/isOpen_fetch_place_button_text" />
+
+                <Button
+                    android:id="@+id/button_isOpen"
+                    style="?android:attr/buttonBarButtonStyle"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/isOpen_is_open_button_text" />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <ProgressBar
+                    android:id="@+id/progressBar_loading"
+                    style="?android:attr/progressBarStyleSmall"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:visibility="invisible" />
+
+            </LinearLayout>
 
             <TextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="3"
-                android:minHeight="48dp"
-                android:text="@string/isOpen_spinner_description" />
-
-            <Spinner
-                android:id="@+id/spinner_time_zones"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="7"
-                android:minHeight="48dp"
-                android:padding="10dp" />
-
-        </LinearLayout>
-
-        <EditText
-            android:id="@+id/editText_is_open_date"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:autofillHints=""
-            android:clickable="false"
-            android:cursorVisible="false"
-            android:focusable="false"
-            android:focusableInTouchMode="false"
-            android:hint="@string/isOpen_date_hint"
-            android:inputType="date"
-            android:longClickable="false"
-            android:minHeight="48dp" />
-
-        <EditText
-            android:id="@+id/editText_is_open_time"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:autofillHints=""
-            android:clickable="false"
-            android:cursorVisible="false"
-            android:focusable="false"
-            android:focusableInTouchMode="false"
-            android:hint="@string/isOpen_time_hint"
-            android:inputType="time"
-            android:longClickable="false"
-            android:minHeight="48dp" />
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/button_fetchPlace"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/isOpen_fetch_place_button_text"
-                tools:ignore="ButtonStyle" />
-
-            <Button
-                android:id="@+id/button_isOpen"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:text="@string/isOpen_is_open_button_text"
-                tools:ignore="ButtonStyle" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <ProgressBar
-                android:id="@+id/progressBar_loading"
-                style="?android:attr/progressBarStyleSmall"
+                android:id="@+id/textView_response"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:visibility="invisible" />
+                android:freezesText="true"
+                android:textIsSelectable="true" />
 
         </LinearLayout>
+    </ScrollView>
 
-        <TextView
-            android:id="@+id/textView_response"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:freezesText="true"
-            android:textIsSelectable="true" />
-
-    </LinearLayout>
-
-</ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/demo-kotlin/app/src/main/res/menu/main_activity_menu.xml
+++ b/demo-kotlin/app/src/main/res/menu/main_activity_menu.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Copyright 2020 Google LLC
 
@@ -15,12 +16,10 @@
 -->
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:app="http://schemas.android.com/apk/res-auto">
-
+    xmlns:app="http://schemas.android.com/apk/res-auto">
   <item
-    android:id="@+id/search"
-    android:icon="@drawable/ic_search_black_24dp"
-    android:title="@string/search"
-    app:actionViewClass="com.google.android.material.search.SearchView"
-    app:showAsAction="collapseActionView|ifRoom" />
+      android:id="@+id/action_exit"
+      android:icon="@drawable/ic_exit_to_app_black_24dp"
+      android:title="@string/action_exit"
+      app:showAsAction="always" />
 </menu>

--- a/demo-kotlin/app/src/main/res/values/strings.xml
+++ b/demo-kotlin/app/src/main/res/values/strings.xml
@@ -159,6 +159,7 @@
   <string name="search_a_place">Search for a Place</string>
   <string name="programmatic_place_predictions_instructions" translatable="false">This activity demonstrates as-you-type programmatic place predictions. Tap on the search icon on the toolbar and search for a place.</string>
   <string name="programmatic_place_predictions_no_matches" translatable="false">No matching search results</string>
+  <string name="programmatic_place_predictions_error" translatable="false">Error fetching place search results</string>
 
   <!-- FIND CURRENT PLACE -->
 

--- a/demo-kotlin/app/src/main/res/values/strings.xml
+++ b/demo-kotlin/app/src/main/res/values/strings.xml
@@ -29,6 +29,9 @@
 
   <string name="error_api_key" translatable="false">No API key defined in gradle.properties</string>
 
+  <!-- Text for exit menu item. -->
+  <string name="action_exit" translatable="false">Exit</string>
+
   <!-- Text for raw results checkbox. When checked raw return values will be displayed. -->
   <string name="display_raw_results" translatable="false">Display raw results?</string>
 
@@ -154,7 +157,8 @@
   <string name="programmatic_autocomplete_geocoding">Programmatic Autocomplete + Geocoding</string>
   <string name="search">Search</string>
   <string name="search_a_place">Search for a Place</string>
-  <string name="programmatic_place_predictions_instructions">This activity demonstrates as-you-type programmatic place predictions. Tap on the search icon on the toolbar and search for a place.</string>
+  <string name="programmatic_place_predictions_instructions" translatable="false">This activity demonstrates as-you-type programmatic place predictions. Tap on the search icon on the toolbar and search for a place.</string>
+  <string name="programmatic_place_predictions_no_matches" translatable="false">No matching search results</string>
 
   <!-- FIND CURRENT PLACE -->
 


### PR DESCRIPTION
This change updates the demo app to support edge-to-edge displays by default.

Key changes:
- A `BaseActivity` is introduced to consolidate the logic for setting up edge-to-edge display. All activities now inherit from this class.
- The app theme is updated to `Theme.Material3.DayNight.NoActionBar`.
- Layouts are refactored to use `MaterialToolbar` and `ConstraintLayout` for a more modern and consistent look.
- The `ProgrammaticAutocompleteGeocodingActivity` is updated to use the new `SearchBar` and `SearchView` components from Material Design.
- Window insets are now correctly handled in `BaseActivity` to prevent UI elements from being obscured by system bars.